### PR TITLE
Load this mod after Vanilla Weapons Expanded - Laser

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -39,6 +39,7 @@
     <li>Ludeon.RimWorld.Ideology</li>
     <li>brrainz.harmony</li>
     <li>OskarPotocki.VanillaFactionsExpanded.Core</li>
+    <li>VanillaExpanded.VWEL</li>
   </loadAfter>
 	<incompatibleWith>
 		<li>n7huntsman.combatshields</li> 


### PR DESCRIPTION
To define the warcasket laser bolter, Vanilla Weapons Expanded - Laser must be loaded before Vanilla Factions Expanded - Pirates. Otherwise the following error appears in the log after launching the game:

https://gist.github.com/8d6afd9cf9003c11148b0d0d32061352

This PR adds VWE-L to the loadAfter list of VFE-P to let players know about this requirement.
